### PR TITLE
Tweak income monthly/yearly stuff

### DIFF
--- a/app/components/income-form.js
+++ b/app/components/income-form.js
@@ -3,27 +3,31 @@ const { Component } = Ember;
 
 export default Component.extend({
   income: null,
+  isPension: false,
   incomeSources: [
-        { label: 'Investment', value: 'investment' },
-        { label: 'Child Support Alimony', value: 'child support alimony' },
-        { label: 'Property Rental', value: 'property rental' },
-        { label: 'Pension', value: 'pension' },
-        { label: 'Other', value: 'other' }
+    { label: 'Investment', value: 'investment' },
+    { label: 'Child Support Alimony', value: 'child support alimony' },
+    { label: 'Property Rental', value: 'property rental' },
+    { label: 'Pension', value: 'pension' },
+    { label: 'Other', value: 'other' }
   ],
   pensionTypes: [
-        { label: 'Canada Pension Plan (CPP)', value: 'canada pension plan' },
-        { label: 'Old Age Security', value: 'old age security' },
-        { label: 'Work Pension', value: 'work pension' },
-        { label: 'Other', value: 'other' }
+    { label: 'Canada Pension Plan (CPP)', value: 'canada pension plan' },
+    { label: 'Old Age Security', value: 'old age security' },
+    { label: 'Work Pension', value: 'work pension' },
+    { label: 'Other', value: 'other' }
   ],
   frequencies: [
-        { label: 'Yearly', value: 'yearly' },
-        { label: 'Monthly', value: 'monthly' }
+    { label: 'Yearly', value: 'yearly' },
+    { label: 'Monthly', value: 'monthly' }
   ],
   actions: {
     remove() {
       let value = this.get('income');
       this.sendAction('removeIncome', value);
+    },
+    changeFrequencies(frequency) {
+      this.set('income.frequency', frequency);
     },
     changeIncomeSource(value) {
       this.set('income.income_source', value);
@@ -39,6 +43,5 @@ export default Component.extend({
     changePensionSource(value) {
       this.set('income.pension_source', value);
     }
-  },
-  isPension: false
+  }
 });

--- a/app/models/income.js
+++ b/app/models/income.js
@@ -2,10 +2,9 @@ import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 
 export default Model.extend({
+  frequency: attr('string', {defaultValue: 'yearly'}),
   income_source: attr('string'),
   pension_source: attr('string'),
   person_id: attr('string'),
-  value: attr('integer'),
-  monthly_value: attr('integer'),
-  yearly_value: attr('integer')
+  value: attr('number')
 });

--- a/app/templates/components/income-form.hbs
+++ b/app/templates/components/income-form.hbs
@@ -12,21 +12,26 @@
 
 <div class="row">
   {{#form-field label="Income" class="column"}}
-    {{currency-input value=income.value}}
+    {{currency-input unmaskedValue=income.value}}
     {{#if income.value}}
       <span class="help">
                 or
-        {{#if income.isYearly}}
-          <strong>{{format-number income.monthly_value style="currency" currency="CAD"}}</strong> per month
+      <strong>{{format-number income.value style="currency" currency="CAD"}}</strong>
+        {{#if (eq income.frequency 'monthly')}}
+          per month
         {{else}}
-          <strong>{{format-number income.yearly_value style="currency" currency="CAD"}}</strong> per year
+          per year
         {{/if}}
-            </span>
+      </span>
     {{/if}}
   {{/form-field}}
   {{#form-field label="Frequency" class="column"}}
-    {{select-list content=frequencies optionValuePath="value" optionLabelPath="label" required=true
-                  change="changeFrequencies"}}
+    {{select-list
+      change="changeFrequencies"
+      content=frequencies
+      optionValuePath="value"
+      optionLabelPath="label"
+      required=true}}
   {{/form-field}}
 </div>
 <div class="row">

--- a/yarn.lock
+++ b/yarn.lock
@@ -972,8 +972,8 @@ clean-css-promise@^0.1.0:
     pinkie-promise "^2.0.0"
 
 clean-css@^3.4.5:
-  version "3.4.22"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-3.4.22.tgz#db323064f752028778233b58c54cd8535f860892"
+  version "3.4.23"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-3.4.23.tgz#604fbbca24c12feb59b02f00b84f1fb7ded6d001"
   dependencies:
     commander "2.8.x"
     source-map "0.4.x"
@@ -2578,13 +2578,24 @@ glob@3.2.x:
     inherits "2"
     minimatch "0.3"
 
-glob@7.0.3, glob@7.0.x, glob@~7.0.3:
+glob@7.0.3, glob@~7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.3.tgz#0aa235931a4a96ac13d60ffac2fb877bd6ed4f58"
   dependencies:
     inflight "^1.0.4"
     inherits "2"
     minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@7.0.x, glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.6.tgz#211bafaf49e525b8cd93260d14ab136152b3f57a"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -2605,17 +2616,6 @@ glob@^6.0.0:
     inflight "^1.0.4"
     inherits "2"
     minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -2928,13 +2928,9 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
 
-is-git-url@0.2.0:
+is-git-url@0.2.0, is-git-url@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/is-git-url/-/is-git-url-0.2.0.tgz#b9ce0fb044821c88880213d602db03bdb255da1b"
-
-is-git-url@^0.2.0:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/is-git-url/-/is-git-url-0.2.3.tgz#445200d6fbd6da028fb5e01440d9afc93f3ccb64"
 
 is-integer@^1.0.4:
   version "1.0.6"
@@ -5198,13 +5194,9 @@ window-size@^0.1.2:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
 
-wordwrap@0.0.2:
+wordwrap@0.0.2, wordwrap@~0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
-
-wordwrap@~0.0.2:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
 
 wordwrap@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
I was not actually able to reproduce an error where I could not remove
the extra income sources. I did find other errors with the feature
though, and I have fixed them here.

I removed `monthly_value` and `yearly_value` in favor of just using the
normal `value` field, and I added a `frequency` field.

Do we want to do this approach on the API side @ericmaicon?

This PR is related to #9